### PR TITLE
chore: fix pre-commit job causing branch rule violation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,11 +42,11 @@ jobs:
             # -----------------------------------------------------------------
             # NOTE ABOUT THE CONDITIONAL:
             # skip autocommit when testing locally with act
-            # But also only auto-commit to protected branches (main and develop)
-            # to prevent ref errors/Git race conditions when pushing from a local feature/fix branch
+            # AND if the action was triggered by a direct Push
+            # AND the push can only be done to non-protected branched (feature-, fix-, etc)
             # -----------------------------------------------------------------
             - name: Commit changes from pre-commit formatting (if any)
-              if: ${{ !env.ACT && (github.ref == 'refs/head/main' || github.ref == 'refs/heads/develop') }}
+              if: ${{ !env.ACT && github.event_name == 'push &&' github.ref_name != 'main' && github.ref_name != 'develop' }}
               uses: stefanzweifel/git-auto-commit-action@v7
               with:
                   commit_message: 'CI pre-commit: Auto-formatting and linting'

--- a/docs/ci-cd-workflow.md
+++ b/docs/ci-cd-workflow.md
@@ -119,7 +119,7 @@ The CI pipeline runs for every push to a feature/fix branch and every Pull Reque
 1. pre-commit:
     - same pre-commit hook used in local development.
     - enforces code style standard and formatting before static analysis and compilation check
-    - only auto-commit formatting fixes on develop/main branches
+    - auto-formatting in CI-workflow on feature branches
     - triggers on push and pull requests.
 2. check-build-firmware:
     - runs only after `pre-commit` passes


### PR DESCRIPTION
- Forgot that our branch rules sets prevents direct pushes to develop and main branch.
**Explaination:** 
- Before the change, if the pre-commit job needs to format code in the CI-pipeline, it **pushes** back the auto formatted and auto committed code to the current branch.
- But one of the branch rules sets is to reject pushes to develop and main. The only way to introduce changes to develop and main branches is through Pull Request from feature branches.
- Summary: pre-commit tries to push back auto formatted code on develop branch = **Big no no.**

--
**Change**:
- auto formatting can only be pushed back if the current branch is a feature branch