### PR TITLE
chore(ci): fix typo in pre-commit conditional step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
             # AND the push can only be done to non-protected branched (feature-, fix-, etc)
             # -----------------------------------------------------------------
             - name: Commit changes from pre-commit formatting (if any)
-              if: ${{ !env.ACT && github.event_name == 'push &&' github.ref_name != 'main' && github.ref_name != 'develop' }}
+              if: ${{ !env.ACT && github.event_name == 'push' && github.ref_name != 'main' && github.ref_name != 'develop' }}
               uses: stefanzweifel/git-auto-commit-action@v7
               with:
                   commit_message: 'CI pre-commit: Auto-formatting and linting'

--- a/S3/lib/SensorIO/SensorIO.cpp
+++ b/S3/lib/SensorIO/SensorIO.cpp
@@ -2,68 +2,53 @@
 
 void WifiData::parseIP(uint8_t *dst, const char *src)
 {
-    size_t i;
+    size_t       i;
     unsigned int temp[4];
 
-    sscanf
-    (
-        src, "%u.%u.%u.%u",
-        &temp[0],
-        &temp[1],
-        &temp[2],
-        &temp[3]
-    );
-    for (i = 0; i < 4; i++)
-        dst[i] = (uint8_t)temp[i];
+    sscanf(src, "%u.%u.%u.%u", &temp[0], &temp[1], &temp[2], &temp[3]);
+    for (i = 0; i < 4; i++) dst[i] = (uint8_t) temp[i];
 }
 
-WifiData::WifiData
-(
-    const uint16_t _port_server,
-    const char *_local_ip,
-    const char *_gateway,
-    const char *_subnet,
-    const char *_primary_dns
-)
-:
-    port_server(_port_server)
+WifiData::WifiData(const uint16_t _port_server, const char *_local_ip, const char *_gateway,
+                   const char *_subnet, const char *_primary_dns)
+    : port_server(_port_server)
 {
     parseIP(bytes_ip, _local_ip);
     local_ip = IPAddress(bytes_ip);
-    
+
     parseIP(bytes_ip, _gateway);
     gateway = IPAddress(bytes_ip);
-    
+
     parseIP(bytes_ip, _subnet);
     subnet = IPAddress(bytes_ip);
-    
+
     parseIP(bytes_ip, _primary_dns);
     primary_dns = IPAddress(bytes_ip);
 }
 
 int httpRequestFormat(SensorData *data, size_t size_buffer_send, const char *host, int port,
-    const char *method)
+                      const char *method)
 {
     return snprintf(data->buffer_send, size_buffer_send,
-        // "POST /packages/%d/logs HTTP/1.1\r\n"
-        "%s /packages/%d/logs HTTP/1.1\r\n"
-        "Host: %s\r\n"
-        "Content-Type: application/json\r\n"
-        "Content-Length: %d\r\n"
-        "Connection: close\r\n"
-        "\r\n"
-        "%s",
-        method, data->id, host, data->length, data->http_body);
+                    // "POST /packages/%d/logs HTTP/1.1\r\n"
+                    "%s /packages/%d/logs HTTP/1.1\r\n"
+                    "Host: %s\r\n"
+                    "Content-Type: application/json\r\n"
+                    "Content-Length: %d\r\n"
+                    "Connection: close\r\n"
+                    "\r\n"
+                    "%s",
+                    method, data->id, host, data->length, data->http_body);
 }
 
 int httpBodyFormat(SensorData *data, size_t size_http_body)
 {
     return snprintf(data->http_body, size_http_body,
-        "{\r\n"
-        "    \"temperature\": %.2f,\r\n"
-        "    \"humidity\": %.2f\r\n"
-        "}",
-        data->temperature, data->humidity);
+                    "{\r\n"
+                    "    \"temperature\": %.2f,\r\n"
+                    "    \"humidity\": %.2f\r\n"
+                    "}",
+                    data->temperature, data->humidity);
 }
 
 int valuesExtract(SensorData *data)
@@ -72,23 +57,17 @@ int valuesExtract(SensorData *data)
 }
 
 void buffersFlush(SensorData *data, size_t size_buf_send, size_t size_http_body,
-    size_t size_buf_recv)
+                  size_t size_buf_recv)
 {
     memset(&data->buffer_send, ' ', size_buf_send);
     memset(&data->http_body, ' ', size_http_body);
     memset(&data->buffer_recv, ' ', size_buf_recv);
 }
 
-
-
-
 size_t sensorDataRead(WiFiClient *client, SensorData *sensor_data)
 {
-    size_t bytes_read = client->read
-    (
-        (uint8_t *)sensor_data->buffer_recv,
-        (size_t)(sizeof(sensor_data->buffer_recv) - 1)
-    );
+    size_t bytes_read = client->read((uint8_t *) sensor_data->buffer_recv,
+                                     (size_t) (sizeof(sensor_data->buffer_recv) - 1));
     sensor_data->buffer_recv[bytes_read] = '\0';
 
     return bytes_read;
@@ -103,10 +82,10 @@ void printStringDelay(int delay_ms, const char *string)
 void sensorLogsSend(SensorData *sensor_data, const char *method_http)
 {
     WiFiClientSecure client;
-    int request;
-    const int  https_port_server = AZURE_PORT;
-    const char *host = AZURE_HOST;
-    const char *azure_root_ca = BACKEND_CA_ROOT;
+    int              request;
+    const int        https_port_server = AZURE_PORT;
+    const char      *host = AZURE_HOST;
+    const char      *azure_root_ca = BACKEND_CA_ROOT;
 
     client.setCACert(azure_root_ca);
     Serial.printf("\nConnecting for %s to %s:%d\n", method_http, host, https_port_server);
@@ -148,7 +127,7 @@ void responseStatusPrint(WiFiClientSecure &client, const char *method_http)
         while (client.available())
         {
             String response;
-            int received_status_code;
+            int    received_status_code;
 
             response = client.readStringUntil('\n');
             if (!response.startsWith("HTTP/1.1"))
@@ -159,45 +138,25 @@ void responseStatusPrint(WiFiClientSecure &client, const char *method_http)
             received_status_code = response.substring(9).toInt();
             if (received_status_code == success_status_code)
             {
-                Serial.printf
-                (
-                    "Success: Sensor logs successfully %s (%d)\n",
-                    method_http,
-                    success_status_code
-                );
-
+                Serial.printf("Success: Sensor logs successfully %s (%d)\n", method_http,
+                              success_status_code);
             }
             else if (received_status_code >= 200 && received_status_code < 300)
             {
-                Serial.printf
-                (
-                    "Success: Request successfully sent with status code (%d)\n",
-                    received_status_code
-                );
-
+                Serial.printf("Success: Request successfully sent with status code (%d)\n",
+                              received_status_code);
             }
             else if (received_status_code >= 300 && received_status_code < 400)
             {
-                Serial.printf
-                (
-                    "Success: Redirection with status code (%d)\n",
-                    received_status_code
-                );
-
+                Serial.printf("Success: Redirection with status code (%d)\n", received_status_code);
             }
             else if (received_status_code >= 400 && received_status_code < 500)
             {
-                Serial.printf
-                (
-                    "Client Error: %s with status code (%d)\n",
-                    (
-                        (strcmp(method_http, "PUT") == 0)
-                        ? "Invalid package ID or invalid input data"
-                        : "Bad request. Missing or invalid parameters"
-                        ),
-                    received_status_code
-                );
-
+                Serial.printf("Client Error: %s with status code (%d)\n",
+                              ((strcmp(method_http, "PUT") == 0)
+                                   ? "Invalid package ID or invalid input data"
+                                   : "Bad request. Missing or invalid parameters"),
+                              received_status_code);
             }
             else if (received_status_code >= 500 && received_status_code <= 511)
                 Serial.printf("Server error (%d)\n", received_status_code);
@@ -213,36 +172,35 @@ void responseStatusPrint(WiFiClientSecure &client, const char *method_http)
             break;
         delay(10);
     }
-
 }
 
 void runBroker(WifiData *wifi_data, SensorData *sensor_data)
 {
     size_t bytes_read;
-    char message[64];
+    char   message[64];
 
     wifi_data->client = wifi_data->port_server.available();
     if (!wifi_data->client)
         goto skip;
     Serial.println("Sensor package connected.");
-    
+
     while (wifi_data->client.connected())
     {
         if (!wifi_data->client.available())
             continue;
 
         buffersFlush(sensor_data, SIZE_BUF_SEND, SIZE_BODY, SIZE_BUF_RECV);
-    
+
         bytes_read = sensorDataRead(&wifi_data->client, sensor_data);
         valuesExtract(sensor_data);
         sensor_data->length = httpBodyFormat(sensor_data, SIZE_BODY);
         Serial.println(sensor_data->buffer_send);
-        
+
         snprintf(message, sizeof(message), "Server received %d bytes.\n", bytes_read);
         wifi_data->client.print(message);
 
         sensorLogsSend(sensor_data, "POST");
-    
+
         break;
     }
     wifi_data->client.stop();
@@ -254,14 +212,14 @@ skip:
 
 void wifiInit(WifiData *wifi_data)
 {
-    if (!WiFi.config(wifi_data->local_ip, wifi_data->gateway, wifi_data->subnet, wifi_data->primary_dns))
+    if (!WiFi.config(wifi_data->local_ip, wifi_data->gateway, wifi_data->subnet,
+                     wifi_data->primary_dns))
         Serial.println("Failed to config");
-        
+
     WiFi.begin(SECRET_SSID, SECRET_PASSWORD);
     Serial.print("Connecting server to Wifi");
 
-    while (WiFi.status() != WL_CONNECTED)
-        printStringDelay(500, ".");
+    while (WiFi.status() != WL_CONNECTED) printStringDelay(500, ".");
     Serial.print("Connected.\nServer IP: ");
     Serial.println(WiFi.localIP());
 

--- a/S3/lib/SensorIO/SensorIO.h
+++ b/S3/lib/SensorIO/SensorIO.h
@@ -33,30 +33,24 @@ typedef struct
 
 class WifiData
 {
-public:
+  public:
     WiFiClient client;
     WiFiServer port_server;
     IPAddress  local_ip;
     IPAddress  gateway;
     IPAddress  subnet;
     IPAddress  primary_dns;
-    uint8_t bytes_ip[4];
+    uint8_t    bytes_ip[4];
 
     void parseIP(uint8_t *dst, const char *src);
 
-    WifiData
-    (
-        const uint16_t _port_server,
-        const char *_local_ip,
-        const char *_gateway,
-        const char *_subnet,
-        const char *_primary_dns
-    );
+    WifiData(const uint16_t _port_server, const char *_local_ip, const char *_gateway,
+             const char *_subnet, const char *_primary_dns);
 };
 
 /* Flushes HTTP request buffers by filling them with blankspaces */
 void buffersFlush(SensorData *data, size_t size_buf_send, size_t size_http_body,
-    size_t size_buf_recv);
+                  size_t size_buf_recv);
 
 /* Extracts sensor values from a buffer and saves them into individual variables. Returns number of
  * values extracted. */
@@ -68,13 +62,13 @@ int httpBodyFormat(SensorData *data, size_t size_http_body);
 /* Formats a request from a body and saves it into a buffer. Returns request size. */
 // int httpRequestFormat(SensorData *data, size_t size_buffer_send);
 int httpRequestFormat(SensorData *data, size_t size_buffer_send, const char *host, int port,
-    const char *method);
+                      const char *method);
 
-void sensorLogsSend(SensorData *sensor_data, const char *method_http);
-void responseStatusPrint(WiFiClientSecure &client, const char *method_http);
-void printStringDelay(int delay_ms, const char *string);
+void   sensorLogsSend(SensorData *sensor_data, const char *method_http);
+void   responseStatusPrint(WiFiClientSecure &client, const char *method_http);
+void   printStringDelay(int delay_ms, const char *string);
 size_t sensorDataRead(WiFiClient *client, SensorData *sensor_data);
-void wifiInit(WifiData *wifi_data);
-void runBroker(WifiData *wifi_data, SensorData *sensor_data);
+void   wifiInit(WifiData *wifi_data);
+void   runBroker(WifiData *wifi_data, SensorData *sensor_data);
 
 #endif

--- a/S3/lib/SensorIO/backend_ca_cert.h
+++ b/S3/lib/SensorIO/backend_ca_cert.h
@@ -1,5 +1,5 @@
-#define BACKEND_CA_ROOT \
-    "-----BEGIN CERTIFICATE-----\n" \
+#define BACKEND_CA_ROOT                                                  \
+    "-----BEGIN CERTIFICATE-----\n"                                      \
     "MIIDjjCCAnagAwIBAgIQAzrx5qcRqaC7KGSxHQn65TANBgkqhkiG9w0BAQsFADBh\n" \
     "MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\n" \
     "d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBH\n" \
@@ -19,6 +19,5 @@
     "Fdtom/DzMNU+MeKNhJ7jitralj41E6Vf8PlwUHBHQRFXGU7Aj64GxJUTFy8bJZ91\n" \
     "8rGOmaFvE7FBcf6IKshPECBV1/MUReXgRPTqh5Uykw7+U0b6LJ3/iyK5S9kJRaTe\n" \
     "pLiaWN0bfVKfjllDiIGknibVb63dDcY3fe0Dkhvld1927jyNxF1WW6LZZm6zNTfl\n" \
-    "MrY=\n" \
+    "MrY=\n"                                                             \
     "-----END CERTIFICATE-----\n"
-    

--- a/S3/src/main.cpp
+++ b/S3/src/main.cpp
@@ -4,23 +4,16 @@ WifiData   wifi_data(LOCAL_PORT, LOCAL_IP, SUBNET, GATEWAY, PRIMARY_DNS);
 SensorData sensor_data;
 size_t     bytes_read;
 
-
-
-
 void setup()
 {
     int i;
 
     Serial.begin(115200);
 
-    for (i = 0; i < 7; i++)
-        printStringDelay(1000, ".");
+    for (i = 0; i < 7; i++) printStringDelay(1000, ".");
 
     wifiInit(&wifi_data);
 }
-
-
-
 
 void loop()
 {


### PR DESCRIPTION
Fixed typo (missplaced single quote in the conditional step(`github.event_name == 'push &&'`) inside the pre-commit job causing the following error

`Invalid workflow file: .github/workflows/ci.yaml#L1

(Line: 49, Col: 19): Unexpected symbol: 'github'. Located at position 44 within expression: !env.ACT && github.event_name == 'push &&' github.ref_name != 'main' && github.ref_name != 'develop'`

